### PR TITLE
[oneplus] 新增 OnePlus Nord 2 欧洲版 & 部分机型代号/版本描述修正

### DIFF
--- a/brands/oneplus.md
+++ b/brands/oneplus.md
@@ -120,7 +120,7 @@
 
 **OnePlus 7T Pro 5G (`hotdogg`):**
 
-`HD1925`: OnePlus 7T Pro 5G
+`HD1925`: OnePlus 7T Pro 5G T-Mobile 版 / OnePlus Concept One
 
 **OnePlus 8 (`instantnoodle`):**
 
@@ -130,7 +130,7 @@
 
 `IN2013`: OnePlus 8 欧洲/国际版
 
-`IN2015`: OnePlus 8 北美版
+`IN2015`: OnePlus 8 Visible 北美版
 
 **OnePlus 8 (`instantnoodlet`):**
 
@@ -138,7 +138,7 @@
 
 **OnePlus 8 (`instantnoodlevis`):**
 
-`IN2019`: OnePlus 8 5G UW (Verzion)
+`IN2019`: OnePlus 8 UW Verzion 版
 
 **OnePlus 8 Pro (`instantnoodlep`):**
 
@@ -208,15 +208,17 @@
 
 `AC2003`: OnePlus Nord 欧洲/国际版
 
-**OnePlus Nord N10 (`billie8t`):**
+**OnePlus Nord N10 (`billie8`):**
 
 `BE2025`: OnePlus Nord N10 Metro 版
 
 `BE2026`: OnePlus Nord N10 北美版
 
-`BE2028`: OnePlus Nord N10 T-Mobile 版
-
 `BE2029`: OnePlus Nord N10 国际版
+
+**OnePlus Nord N10 (`billie8t`):**
+
+`BE2028`: OnePlus Nord N10 T-Mobile 版
 
 **OnePlus Nord N100 (`bengal`):**
 
@@ -238,10 +240,12 @@
 
 **OnePlus Nord CE (`ebba`):**
 
-`EB2101`: OnePlus Nord CE 5G 印度版
+`EB2101`: OnePlus Nord CE 印度版
 
-`EB2103`: OnePlus Nord CE 5G 欧洲/国际版
+`EB2103`: OnePlus Nord CE 欧洲/国际版
 
 **OnePlus Nord 2 (`denniz`):**
 
-`DN2101`: OnePlus Nord 2 5G 印度版
+`DN2101`: OnePlus Nord 2 印度版
+
+`DN2103`: OnePlus Nord 2 欧洲版

--- a/brands/oneplus_en.md
+++ b/brands/oneplus_en.md
@@ -115,7 +115,7 @@
 
 **OnePlus 7T Pro 5G (`hotdogg`):**
 
-`HD1925`: OnePlus 7T Pro 5G
+`HD1925`: OnePlus 7T Pro 5G T-Mobile / OnePlus Concept One
 
 **OnePlus 8 (`instantnoodle`):**
 
@@ -125,7 +125,7 @@
 
 `IN2013`: OnePlus 8 EU / Global
 
-`IN2015`: OnePlus 8 North America
+`IN2015`: OnePlus 8 Visible North America
 
 **OnePlus 8 (`instantnoodlet`):**
 
@@ -133,7 +133,7 @@
 
 **OnePlus 8 (`instantnoodlevis`):**
 
-`IN2019`: OnePlus 8 5G UW (Verzion)
+`IN2019`: OnePlus 8 UW Verzion
 
 **OnePlus 8 Pro (`instantnoodlep`):**
 
@@ -203,15 +203,17 @@
 
 `AC2003`: OnePlus Nord EU / Global
 
-**OnePlus Nord N10 (`billie8t`):**
+**OnePlus Nord N10 (`billie8`):**
 
 `BE2025`: OnePlus Nord N10 Metro
 
 `BE2026`: OnePlus Nord N10 North America
 
-`BE2028`: OnePlus Nord N10 T-Mobile
-
 `BE2029`: OnePlus Nord N10 Global
+
+**OnePlus Nord N10 (`billie8t`):**
+
+`BE2028`: OnePlus Nord N10 T-Mobile
 
 **OnePlus Nord N100 (`bengal`):**
 
@@ -233,10 +235,12 @@
 
 **OnePlus Nord CE (`ebba`):**
 
-`EB2101`: OnePlus Nord CE 5G India
+`EB2101`: OnePlus Nord CE India
 
-`EB2103`: OnePlus Nord CE 5G EU / Global
+`EB2103`: OnePlus Nord CE EU / Global
 
 **OnePlus Nord 2 (`denniz`):**
 
 `DN2101`: OnePlus Nord 2 5G India
+
+`DN2103`: OnePlus Nord 2 5G EU


### PR DESCRIPTION
- 去除部分机型不该有的 5G 标识
- 修正 `OnePlus Nord N10` 部分版本代号为 `billie8` [1]
- 修正 `IN2015` 名称为 `OnePlus 8 Visible` [2]
- 为 `HD1925` 增加机型描述 `OnePlus Concept One` [3]
- 为 `OnePlus Nord 2` 新增 `DN2103` 欧洲版型号 [4]

[1] [Android Dump for OnePlus Nord N10 T-Mobile](https://dumps.tadiphone.dev/dumps/oneplus/oneplusn10/-/blob/qssi-user-11-RKQ1.201217.002-2107132159-release-keys/vendor/build.prop#L69)
[2] [OnePlus Software Upgrade for OnePlus 8 Visible](https://www.oneplus.com/support/softwareupgrade/details?code=PM1600329725089)
[3] [YouTube: OnePlus Concept One](https://www.youtube.com/watch?v=xpoEeg2zyNY) (00:01)
[4] [OnePlus OS Update Tracker: OnePlus Nord 2 Oxygen OS 11.3.A.07 EEA](https://t.me/s/OnePlusOTA/264) (Telegram: [@OnePlusOTA](https://t.me/OnePlusOTA))
