### PR TITLE
[oppo] 添加 OPPO Watch 系列

### DIFF
--- a/brands/oppo.md
+++ b/brands/oppo.md
@@ -35,24 +35,6 @@
 
 `PEEM00`: OPPO Find X3 Pro 全网通版
 
-## Watch 系列
-
-**OPPO Watch:**
-
-`OW19W1`: OPPO Watch 46mm
-
-`OW19W2`: OPPO Watch 41mm
-
-`OW19W3`: OPPO Watch 46mm ECG/精钢版
-
-**OPPO Watch 2:**
-
-`OW20W1`: OPPO Watch 2 46mm eSIM 版
-
-`OW19W2`: OPPO Watch 2 42mm 蓝牙版/eSIM 版
-
-`OW19W3`: OPPO Watch 2 46mm ECG
-
 ## Reno 系列
 
 **OPPO Reno:**
@@ -356,3 +338,21 @@
 **OPPO K9:**
 
 `PEXM00`: OPPO K9 全网通版
+
+## Watch 系列
+
+**OPPO Watch:**
+
+`OW19W1`: OPPO Watch 46mm
+
+`OW19W2`: OPPO Watch 41mm
+
+`OW19W3`: OPPO Watch 46mm ECG/精钢版
+
+**OPPO Watch 2:**
+
+`OW20W1`: OPPO Watch 2 46mm eSIM 版
+
+`OW19W2`: OPPO Watch 2 42mm 蓝牙版/eSIM 版
+
+`OW19W3`: OPPO Watch 2 46mm ECG

--- a/brands/oppo.md
+++ b/brands/oppo.md
@@ -35,6 +35,24 @@
 
 `PEEM00`: OPPO Find X3 Pro 全网通版
 
+## Watch 系列
+
+**OPPO Watch:**
+
+`OW19W1`: OPPO Watch 46mm
+
+`OW19W2`: OPPO Watch 41mm
+
+`OW19W3`: OPPO Watch 46mm ECG/精钢版
+
+**OPPO Watch 2:**
+
+`OW20W1`: OPPO Watch 2 46mm eSIM 版
+
+`OW19W2`: OPPO Watch 2 42mm 蓝牙版/eSIM 版
+
+`OW19W3`: OPPO Watch 2 46mm ECG
+
 ## Reno 系列
 
 **OPPO Reno:**

--- a/brands/oppo_global_en.md
+++ b/brands/oppo_global_en.md
@@ -29,18 +29,6 @@
 
 `CPH2173`: OPPO Find X3 Pro
 
-## Watch series
-
-**OPPO Watch (`beluga`):**
-
-`OW19W6`: OPPO Watch 41mm Wi-Fi
-
-`OW19W8`: OPPO Watch 46mm Wi-Fi
-
-**OPPO Watch (`belugaxl`):**
-
-`OW19W12`: OPPO Watch 46mm LTE
-
 ## Reno series
 
 **OPPO Reno:**
@@ -298,3 +286,15 @@
 **OPPO K3:**
 
 `CPH1955`: OPPO K3
+
+## Watch series
+
+**OPPO Watch (`beluga`):**
+
+`OW19W6`: OPPO Watch 41mm Wi-Fi
+
+`OW19W8`: OPPO Watch 46mm Wi-Fi
+
+**OPPO Watch (`belugaxl`):**
+
+`OW19W12`: OPPO Watch 46mm LTE

--- a/brands/oppo_global_en.md
+++ b/brands/oppo_global_en.md
@@ -1,7 +1,7 @@
 # OPPO Global Mobile Phone Models
 
 - Range: International models since 2018
-- Codename: ❌
+- Codename: ⏹
 
 ## Find series
 
@@ -28,6 +28,18 @@
 **OPPO Find X3 Pro:**
 
 `CPH2173`: OPPO Find X3 Pro
+
+## Watch series
+
+**OPPO Watch (`beluga`):**
+
+`OW19W6`: OPPO Watch 41mm Wi-Fi
+
+`OW19W8`: OPPO Watch 46mm Wi-Fi
+
+**OPPO Watch (`belugaxl`):**
+
+`OW19W12`: OPPO Watch 46mm LTE
 
 ## Reno series
 


### PR DESCRIPTION
- 添加国内版 OPPO Watch & OPPO Watch 2 和国际版 OPPO Watch `beluga` `belugaxl`
- 型号为 `OW19W3` 的 `OPPO Watch 2 ECG` 暂未发布，该型号目前暂为内部型号 [1]
- 因 OPPO Watch 系列运行 Android 系统且可以使用 eSIM 卡，故将其列入"手机"列表中
- 国内版 codename 与该代 ECG 版型号相同，暂不标注

[1] [XDA: OPPO Watch 2 leak rumor by @MlgmXyysd](https://www.xda-developers.com/oppo-watch-2-wear-os-snapdragon-wear-4100-rumor/)
