### PR TITLE
添加 OPPO 和 OnePlus 平板代号

### DIFF
--- a/brands/oneplus.md
+++ b/brands/oneplus.md
@@ -372,10 +372,12 @@
 
 `CPH2551`: OnePlus Open
 
-**OnePlus Pad:**
+**OnePlus Pad (`aries`):**
 
 `OPD2203`: OnePlus Pad
 
-**OnePlus Pad Go:**
+**OnePlus Pad Go (`bluey`):**
 
-`OPD2304`: OnePlus Pad Go
+`OPD2304`: OnePlus Pad Go LTE
+
+`OPD2305`: OnePlus Pad Go Wi-Fi

--- a/brands/oneplus_en.md
+++ b/brands/oneplus_en.md
@@ -367,10 +367,12 @@
 
 `CPH2551`: OnePlus Open
 
-**OnePlus Pad:**
+**OnePlus Pad (`aries`):**
 
 `OPD2203`: OnePlus Pad
 
-**OnePlus Pad Go:**
+**OnePlus Pad Go (`bluey`):**
 
-`OPD2304`: OnePlus Pad Go
+`OPD2304`: OnePlus Pad Go LTE
+
+`OPD2305`: OnePlus Pad Go Wi-Fi

--- a/brands/oppo_cn.md
+++ b/brands/oppo_cn.md
@@ -550,7 +550,7 @@
 
 `OPD2102`: OPPO Pad Air
 
-**OPPO Pad 2:**
+**OPPO Pad 2 (`aries`):**
 
 `OPD2201`: OPPO Pad 2
 
@@ -592,6 +592,10 @@
 
 `OWW213`: OPPO Watch 3 SE
 
-**OPPO Watch 4 (`comet`):**
+**OPPO Watch 4 Pro (`comet`):**
 
 `OWW221`: OPPO Watch 4 Pro
+
+**OPPO Watch 4 Round (`star`):**
+
+`OWW231`: OPPO Watch 4 Round


### PR DESCRIPTION
添加代号为 star 的圆形手表，OPPO Watch 4 Round 为国内暂定的 marketname，在国外将作为 OnePlus Watch 2 发布