### PR TITLE
[oneplus] Major update

### DIFF
--- a/brands/oneplus.md
+++ b/brands/oneplus.md
@@ -22,7 +22,7 @@
 
 **OnePlus X (`onyx`):**
 
-`ONE E1001`: OnePlus X 移动/联通版
+`ONE E1001`: OnePlus X 移动版 / 联通版
 
 `ONE E1000`: OnePlus X 全网通版
 
@@ -70,7 +70,7 @@
 
 `GM1903`: OnePlus 7 欧洲版
 
-`GM1905`: OnePlus 7 北美版/国际版
+`GM1905`: OnePlus 7 北美版 / 国际版
 
 **OnePlus 7 Pro (`guacamole`):**
 
@@ -80,7 +80,7 @@
 
 `GM1913`: OnePlus 7 Pro 欧洲版
 
-`GM1915`: OnePlus 7 Pro 北美版/国际版
+`GM1915`: OnePlus 7 Pro 北美版 / 国际版
 
 **OnePlus 7 Pro (`guacamolet`):**
 
@@ -102,7 +102,7 @@
 
 `HD1903`: OnePlus 7T 欧洲版
 
-`HD1905`: OnePlus 7T 北美版/国际版
+`HD1905`: OnePlus 7T 北美版 / 国际版
 
 **OnePlus 7T (`hotdogt`):**
 
@@ -114,7 +114,7 @@
 
 `HD1911`: OnePlus 7T Pro 印度版
 
-`HD1913`: OnePlus 7T Pro 欧洲版/国际版
+`HD1913`: OnePlus 7T Pro 欧洲版 / 国际版
 
 **OnePlus 7T Pro 5G (`hotdogg`):**
 
@@ -128,7 +128,7 @@
 
 `IN2013`: OnePlus 8 欧洲版
 
-`IN2015`: OnePlus 8 北美版/国际版
+`IN2015`: OnePlus 8 北美版 / 国际版
 
 **OnePlus 8 (`instantnoodlet`):**
 
@@ -136,7 +136,7 @@
 
 **OnePlus 8 (`instantnoodlevis`):**
 
-`IN2019`: OnePlus 8 Visible 版/Verizon 版
+`IN2019`: OnePlus 8 Visible 版 / Verizon 版
 
 **OnePlus 8 Pro (`instantnoodlep`):**
 
@@ -146,7 +146,7 @@
 
 `IN2023`: OnePlus 8 Pro 欧洲版
 
-`IN2025`: OnePlus 8 Pro 北美版/国际版
+`IN2025`: OnePlus 8 Pro 北美版 / 国际版
 
 **OnePlus 8T (`kebab`):**
 
@@ -156,7 +156,7 @@
 
 `KB2003`: OnePlus 8T 欧洲版
 
-`KB2005`: OnePlus 8T 北美版/国际版
+`KB2005`: OnePlus 8T 北美版 / 国际版 / OnePlus 8T Concept
 
 **OnePlus 8T+ (`kebabt`):**
 
@@ -176,7 +176,7 @@
 
 `LE2113`: OnePlus 9 欧洲版
 
-`LE2115`: OnePlus 9 北美版/国际版
+`LE2115`: OnePlus 9 北美版 / 国际版
 
 **OnePlus 9 (`lemonadet`):**
 
@@ -194,7 +194,7 @@
 
 `LE2123`: OnePlus 9 Pro 欧洲版
 
-`LE2125`: OnePlus 9 Pro 北美版/国际版
+`LE2125`: OnePlus 9 Pro 北美版 / 国际版
 
 **OnePlus 9 Pro (`lemonadept`):**
 
@@ -212,7 +212,7 @@
 
 `NE2211`: OnePlus 10 Pro 印度版
 
-`NE2213`: OnePlus 10 Pro 欧洲版/国际版
+`NE2213`: OnePlus 10 Pro 欧洲版 / 国际版
 
 `NE2215`: OnePlus 10 Pro 北美版
 
@@ -224,19 +224,19 @@
 
 `CPH2423`: OnePlus 10R 印度版
 
-`CPH2411`: OnePlus 10R Endurance 印度版
+`CPH2411`: OnePlus 10R 长寿版 印度版
 
-**OnePlus Ace 竞速版 (`qqcandy`):**
+**OnePlus Ace Race (`qqcandy`):**
 
 `PGZ110`: OnePlus Ace 竞速版 国行版
 
 **OnePlus Ace Pro / OnePlus 10T (`ovaltine`):**
 
-`PGP110`: OnePlus Ace Pro 国行版
+`PGP110`: OnePlus Ace Pro 国行版 / 原神限定版 国行版
 
 `CPH2413`: OnePlus 10T 印度版
 
-`CPH2415`: OnePlus 10T 欧洲版/国际版
+`CPH2415`: OnePlus 10T 欧洲版 / 国际版
 
 `CPH2417`: OnePlus 10T 北美版
 
@@ -248,13 +248,13 @@
 
 `CPH2447`: OnePlus 11 印度版
 
-`CPH2449`: OnePlus 11 欧洲版/国际版
+`CPH2449`: OnePlus 11 欧洲版 / 国际版 / OnePlus 11 Concept
 
 `CPH2451`: OnePlus 11 北美版
 
 **OnePlus Ace 2 / OnePlus 11R (`udon`):**
 
-`PHK110`: OnePlus Ace 2 国行版
+`PHK110`: OnePlus Ace 2 国行版 / 原神定制礼盒 国行版
 
 `CPH2487`: OnePlus 11R 印度版
 
@@ -266,9 +266,9 @@
 
 `CPH2493`: OnePlus Nord 3 欧洲版
 
-**OnePlus Ace 2 Pro (`xigua`):**
+**OnePlus Ace 2 Pro (`xigua`) / OnePlus Ace 2 Pro Genshin Impact (`xiyou`):**
 
-`PJA110`: OnePlus Ace 2 Pro 国行版
+`PJA110`: OnePlus Ace 2 Pro 国行版 / 原神派蒙主题礼盒 国行版
 
 **OnePlus 12 (`waffle`):**
 
@@ -276,19 +276,19 @@
 
 `CPH2573`: OnePlus 12 印度版
 
-`CPH2581`: OnePlus 12 欧洲版/国际版
+`CPH2581`: OnePlus 12 欧洲版 / 国际版
 
 `CPH2583`: OnePlus 12 北美版
 
-**OnePlus Ace 3 / OnePlus 12R (`aston`):**
+**OnePlus Ace 3 / OnePlus 12R (`aston`) / OnePlus Ace 3 Genshin Impact Edition / OnePlus 12R Genshin Impact Edition (`martin`):**
 
-`PJE110`: OnePlus Ace 3 国行版
+`PJE110`: OnePlus Ace 3 国行版 / 原神刻晴定制机 国行版
 
-`CPH2585`: OnePlus 12R 印度版
+`CPH2585`: OnePlus 12R 印度版 / 原神刻晴定制机 印度版
 
-`CPH2609`: OnePlus 12R 欧洲版/国际版
+`CPH2609`: OnePlus 12R 欧洲版 / 国际版 / 原神刻晴定制机 欧洲版 / 国际版
 
-`CPH2611`: OnePlus 12R 北美版
+`CPH2611`: OnePlus 12R 北美版 / 原神刻晴定制机 北美版
 
 **OnePlus Ace 3V (`audi`):**
 
@@ -302,7 +302,7 @@
 
 `AC2001`: OnePlus Nord 印度版
 
-`AC2003`: OnePlus Nord 欧洲版/国际版
+`AC2003`: OnePlus Nord 欧洲版 / 国际版
 
 **OnePlus Nord 2 (`denniz`):**
 
@@ -316,11 +316,17 @@
 
 `CPH2401`: OnePlus Nord 2T 印度版
 
+**OnePlus Nord 4 (`avalon`):**
+
+`CPH2661`: OnePlus Nord 4 印度版
+
+`CPH2663`: OnePlus Nord 4 欧洲版 / 国际版
+
 **OnePlus Nord CE (`ebba`):**
 
 `EB2101`: OnePlus Nord CE 印度版
 
-`EB2103`: OnePlus Nord CE 欧洲版/国际版
+`EB2103`: OnePlus Nord CE 欧洲版 / 国际版
 
 **OnePlus Nord CE 2 (`ivan`):**
 
@@ -330,27 +336,31 @@
 
 `CPH2381`: OnePlus Nord CE 2 Lite 印度版
 
-`CPH2409`: OnePlus Nord CE 2 Lite 欧洲版/国际版
+`CPH2409`: OnePlus Nord CE 2 Lite 欧洲版 / 国际版
 
-**OnePlus Nord CE 3:**
+**OnePlus Nord CE 3 (`ziti`):**
 
 `CPH2569`: OnePlus Nord CE 3 印度版
 
-**OnePlus Nord CE 3 Lite:**
+**OnePlus Nord CE 3 Lite / OnePlus Nord N30 (`larry`):**
 
 `CPH2465`: OnePlus Nord CE 3 Lite 国际版
 
 `CPH2467`: OnePlus Nord CE 3 Lite 印度版
 
-**OnePlus Nord CE4:**
+`CPH2513`: OnePlus Nord N30 北美版
 
-`CPH2613`: OnePlus Nord CE4 印度版
+`CPH2515`: OnePlus Nord N30 T-Mobile 版
 
-**OnePlus Nord CE4 Lite:**
+**OnePlus Nord CE 4 (`benz`):**
 
-`CPH2619`: OnePlus Nord CE4 Lite 印度版
+`CPH2613`: OnePlus Nord CE 4 印度版
 
-`CPH2621`: OnePlus Nord CE4 Lite 欧洲版/国际版
+**OnePlus Nord CE 4 Lite (`camry`):**
+
+`CPH2619`: OnePlus Nord CE 4 Lite 印度版
+
+`CPH2621`: OnePlus Nord CE 4 Lite 欧洲版 / 国际版
 
 **OnePlus Nord N10 (`billie8`):**
 
@@ -358,7 +368,7 @@
 
 `BE2026`: OnePlus Nord N10 北美版
 
-`BE2029`: OnePlus Nord N10 欧洲版/国际版
+`BE2029`: OnePlus Nord N10 欧洲版 / 国际版
 
 **OnePlus Nord N10 (`billie8t`):**
 
@@ -376,17 +386,13 @@
 
 **OnePlus Nord N20:**
 
-`GN2200` `CPH2459`: OnePlus Nord N20
+`GN2200`: OnePlus Nord N20
+
+`CPH2459`: OnePlus Nord N20
 
 **OnePlus Nord N20 SE:**
 
-`CPH2469`: OnePlus Nord 20 SE
-
-**OnePlus Nord N30:**
-
-`CPH2513`: OnePlus Nord N30 北美版
-
-`CPH2515`: OnePlus Nord N30 T-Mobile 版
+`CPH2469`: OnePlus Nord N20 SE
 
 **OnePlus Nord N30 SE (`fanli`):**
 
@@ -420,17 +426,19 @@
 
 `OPD2305`: OnePlus Pad Go Wi-Fi
 
-**OnePlus Pad Pro (`caihong`):**
+**OnePlus Pad 2 / OnePlus Pad Pro (`rainbow`):**
 
 `OPD2404`: OnePlus Pad Pro 国行版
 
+`OPD2403`: OnePlus Pad 2 国际版
+
 ## 一加手表/手环
 
-**OnePlus Band:**
+**OnePlus Band (`audio`):**
 
 `W101IN`: OnePlus Band 印度版
 
-**OnePlus Nord Watch:**
+**OnePlus Nord Watch (`newton`):**
 
 `OPBBE221`: OnePlus Nord Watch 国际版
 
@@ -442,10 +450,14 @@
 
 `W301GB`: OnePlus Watch 国际版 / 钴合金限定版 (国际)
 
-**OnePlus Watch 2 (`bagel`):**
+**OnePlus Watch 2R / OnePlus Watch 2 (CN) (`bagel`):**
 
 `OPWW234`: OnePlus Watch 2 国行版
 
+`OPWWE234`: OnePlus Watch 2R 国际版
+
 **OnePlus Watch 2 (`almond`):**
+
+`OPWWE231`: OnePlus Watch 2 国际版
 
 `OPWWE231`: OnePlus Watch 2 国际版

--- a/brands/oneplus.md
+++ b/brands/oneplus.md
@@ -8,7 +8,7 @@
 
 **OnePlus One (`bacon`):**
 
-`ONE A0001`: OnePlus One 移动版
+`ONE A0001`: OnePlus One 全网通版 / 移动版 / 国际版
 
 `ONE A1001`: OnePlus One 联通版
 
@@ -22,9 +22,9 @@
 
 **OnePlus X (`onyx`):**
 
-`ONE E1001`: OnePlus X 移动版 / 联通版
-
 `ONE E1000`: OnePlus X 全网通版
+
+`ONE E1001`: OnePlus X 移动版 / 联通版
 
 `ONE E1003`: OnePlus X 国际版
 
@@ -232,7 +232,7 @@
 
 **OnePlus Ace Pro / OnePlus 10T (`ovaltine`):**
 
-`PGP110`: OnePlus Ace Pro 国行版 / 原神限定版 国行版
+`PGP110`: OnePlus Ace Pro 国行版 / 原神限定版
 
 `CPH2413`: OnePlus 10T 印度版
 
@@ -254,7 +254,7 @@
 
 **OnePlus Ace 2 / OnePlus 11R (`udon`):**
 
-`PHK110`: OnePlus Ace 2 国行版 / 原神定制礼盒 国行版
+`PHK110`: OnePlus Ace 2 国行版 / 原神定制礼盒
 
 `CPH2487`: OnePlus 11R 印度版
 
@@ -268,7 +268,7 @@
 
 **OnePlus Ace 2 Pro (`xigua`) / OnePlus Ace 2 Pro Genshin Impact (`xiyou`):**
 
-`PJA110`: OnePlus Ace 2 Pro 国行版 / 原神派蒙主题礼盒 国行版
+`PJA110`: OnePlus Ace 2 Pro 国行版 / 原神派蒙主题礼盒
 
 **OnePlus 12 (`waffle`):**
 
@@ -282,13 +282,13 @@
 
 **OnePlus Ace 3 / OnePlus 12R (`aston`) / OnePlus Ace 3 Genshin Impact Edition / OnePlus 12R Genshin Impact Edition (`martin`):**
 
-`PJE110`: OnePlus Ace 3 国行版 / 原神刻晴定制机 国行版
+`PJE110`: OnePlus Ace 3 国行版 / 原神刻晴定制机
 
-`CPH2585`: OnePlus 12R 印度版 / 原神刻晴定制机 印度版
+`CPH2585`: OnePlus 12R 印度版 / 原神刻晴定制机
 
-`CPH2609`: OnePlus 12R 欧洲版 / 国际版 / 原神刻晴定制机 欧洲版 / 国际版
+`CPH2609`: OnePlus 12R 欧洲版 / 国际版 / 原神刻晴定制机
 
-`CPH2611`: OnePlus 12R 北美版 / 原神刻晴定制机 北美版
+`CPH2611`: OnePlus 12R 北美版 / 原神刻晴定制机
 
 **OnePlus Ace 3V (`audi`):**
 
@@ -412,7 +412,7 @@
 
 ## 一加平板/折叠屏
 
-**OnePlus Open (`hedwig`):**
+**OnePlus Open (`hedwig`, `xueying`):**
 
 `CPH2551`: OnePlus Open
 
@@ -426,11 +426,11 @@
 
 `OPD2305`: OnePlus Pad Go Wi-Fi
 
-**OnePlus Pad 2 / OnePlus Pad Pro (`rainbow`):**
+**OnePlus Pad 2 / OnePlus Pad Pro (`rainbow`, `caihong`):**
 
-`OPD2404`: OnePlus Pad Pro 国行版
+`OPD2404`: OnePlus Pad Pro
 
-`OPD2403`: OnePlus Pad 2 国际版
+`OPD2403`: OnePlus Pad 2
 
 ## 一加手表/手环
 
@@ -440,7 +440,7 @@
 
 **OnePlus Nord Watch (`newton`):**
 
-`OPBBE221`: OnePlus Nord Watch 国际版
+`OPBBE221`: OnePlus Nord Watch 
 
 **OnePlus Watch:**
 
@@ -452,12 +452,12 @@
 
 **OnePlus Watch 2R / OnePlus Watch 2 (CN) (`bagel`):**
 
-`OPWW234`: OnePlus Watch 2 国行版
+`OPWW234`: OnePlus Watch 2 (国行)
 
-`OPWWE234`: OnePlus Watch 2R 国际版
+`OPWWE234`: OnePlus Watch 2R
 
 **OnePlus Watch 2 (`almond`):**
 
-`OPWWE231`: OnePlus Watch 2 国际版
+`OPWWE231`: OnePlus Watch 2
 
 `OPWWE231`: OnePlus Watch 2 国际版

--- a/brands/oneplus_en.md
+++ b/brands/oneplus_en.md
@@ -7,7 +7,9 @@
 
 **OnePlus One (`bacon`):**
 
-`ONE A0001` `ONE A1001`: OnePlus One
+`ONE A0001`: OnePlus One China / China Mobile / Global
+
+`ONE A1001`: OnePlus One China Unicom
 
 **OnePlus 2 (`oneplus2`):**
 
@@ -19,7 +21,9 @@
 
 **OnePlus X (`onyx`):**
 
-`ONE E1000` `ONE E1001`: OnePlus X China
+`ONE E1000`: OnePlus X China
+
+`ONE E1001`: OnePlus X China Mobile / China Unicom
 
 `ONE E1003`: OnePlus X Global
 
@@ -63,7 +67,7 @@
 
 `GM1901`: OnePlus 7 India
 
-`GM1903`: OnePlus 7 EU
+`GM1903`: OnePlus 7 Europe
 
 `GM1905`: OnePlus 7 North America / Global
 
@@ -73,7 +77,7 @@
 
 `GM1911`: OnePlus 7 Pro India
 
-`GM1913`: OnePlus 7 Pro EU
+`GM1913`: OnePlus 7 Pro Europe
  
 `GM1915`: OnePlus 7 Pro North America / Global
 
@@ -83,7 +87,7 @@
 
 **OnePlus 7 Pro 5G (`guacamoleg`):**
 
-`GM1920`: OnePlus 7 Pro 5G EU
+`GM1920`: OnePlus 7 Pro 5G Europe
 
 **OnePlus 7 Pro 5G (`guacamoles`):**
 
@@ -95,7 +99,7 @@
 
 `HD1901`: OnePlus 7T India
 
-`HD1903`: OnePlus 7T EU
+`HD1903`: OnePlus 7T Europe
 
 `HD1905`: OnePlus 7T North America / Global
 
@@ -109,7 +113,7 @@
 
 `HD1911`: OnePlus 7T Pro India
 
-`HD1913`: OnePlus 7T Pro EU / Global
+`HD1913`: OnePlus 7T Pro Europe / Global
 
 **OnePlus 7T Pro 5G (`hotdogg`):**
 
@@ -121,7 +125,7 @@
 
 `IN2011`: OnePlus 8 India
 
-`IN2013`: OnePlus 8 EU
+`IN2013`: OnePlus 8 Europe
 
 `IN2015`: OnePlus 8 North America / Global
 
@@ -139,7 +143,7 @@
 
 `IN2021`: OnePlus 8 Pro India
 
-`IN2023`: OnePlus 8 Pro EU
+`IN2023`: OnePlus 8 Pro Europe
 
 `IN2025`: OnePlus 8 Pro North America / Global
 
@@ -149,9 +153,9 @@
 
 `KB2001`: OnePlus 8T India
 
-`KB2003`: OnePlus 8T EU
+`KB2003`: OnePlus 8T Europe
 
-`KB2005`: OnePlus 8T North America / Global
+`KB2005`: OnePlus 8T North America / Global / OnePlus 8T Concept
 
 **OnePlus 8T+ (`kebabt`):**
 
@@ -169,7 +173,7 @@
 
 `LE2111`: OnePlus 9 India
 
-`LE2113`: OnePlus 9 EU
+`LE2113`: OnePlus 9 Europe
 
 `LE2115`: OnePlus 9 North America / Global
 
@@ -187,7 +191,7 @@
 
 `LE2121`: OnePlus 9 Pro India
 
-`LE2123`: OnePlus 9 Pro EU
+`LE2123`: OnePlus 9 Pro Europe
 
 `LE2125`: OnePlus 9 Pro North America / Global
 
@@ -207,7 +211,7 @@
 
 `NE2211`: OnePlus 10 Pro India
 
-`NE2213`: OnePlus 10 Pro EU / Global
+`NE2213`: OnePlus 10 Pro Europe / Global
 
 `NE2215`: OnePlus 10 Pro North America
 
@@ -217,9 +221,9 @@
 
 `PGKM10`: OnePlus Ace China
 
-`CPH2411`: OnePlus 10R Endurance India
-
 `CPH2423`: OnePlus 10R India
+
+`CPH2411`: OnePlus 10R Endurance India
 
 **OnePlus Ace Race (`qqcandy`):**
 
@@ -227,11 +231,11 @@
 
 **OnePlus 10T / OnePlus Ace Pro (`ovaltine`):**
 
-`PGP110`: OnePlus Ace Pro China
+`PGP110`: OnePlus Ace Pro China / Genshin Impact Edition
 
 `CPH2413`: OnePlus 10T India
 
-`CPH2415`: OnePlus 10T EU / Global
+`CPH2415`: OnePlus 10T Europe / Global
 
 `CPH2417`: OnePlus 10T North America
 
@@ -243,13 +247,13 @@
 
 `CPH2447`: OnePlus 11 India
 
-`CPH2449`: OnePlus 11 EU / Global
+`CPH2449`: OnePlus 11 Europe / Global / OnePlus 11 Concept
 
 `CPH2451`: OnePlus 11 North America
 
 **OnePlus 11R / OnePlus Ace 2 (`udon`):**
 
-`PHK110`: OnePlus Ace 2 China
+`PHK110`: OnePlus Ace 2 China / Genshin Impact Edition
 
 `CPH2487`: OnePlus 11R India
 
@@ -259,11 +263,11 @@
 
 `CPH2491`: OnePlus Nord 3 India
 
-`CPH2493`: OnePlus Nord 3 EU
+`CPH2493`: OnePlus Nord 3 Europe
 
-**OnePlus Ace 2 Pro (`xigua`):**
+**OnePlus Ace 2 Pro (`xigua`) / OnePlus Ace 2 Pro Genshin Impact (`xiyou`):**
 
-`PJA110`: OnePlus Ace 2 Pro China
+`PJA110`: OnePlus Ace 2 Pro China / Genshin Impact Edition
 
 **OnePlus 12 (`waffle`):**
 
@@ -271,19 +275,19 @@
 
 `CPH2573`: OnePlus 12 India
 
-`CPH2581`: OnePlus 12 EU / Global
+`CPH2581`: OnePlus 12 Europe / Global
 
 `CPH2583`: OnePlus 12 North America
 
-**OnePlus Ace 3 / OnePlus 12R (`aston`):**
+**OnePlus Ace 3 / OnePlus 12R (`aston`) / OnePlus Ace 3 Genshin Impact Edition / OnePlus 12R Genshin Impact Edition (`martin`):**
 
-`PJE110`: OnePlus Ace 3 China
+`PJE110`: OnePlus Ace 3 China / Genshin Impact Edition
 
-`CPH2585`: OnePlus 12R India
+`CPH2585`: OnePlus 12R India / Genshin Impact Edition
 
-`CPH2609`: OnePlus 12R EU / Global
+`CPH2609`: OnePlus 12R Europe / Global / Genshin Impact Edition
 
-`CPH2611`: OnePlus 12R North America
+`CPH2611`: OnePlus 12R North America / Genshin Impact Edition
 
 **OnePlus Ace 3V (`audi`):**
 
@@ -297,13 +301,13 @@
 
 `AC2001`: OnePlus Nord India
 
-`AC2003`: OnePlus Nord EU / Global
+`AC2003`: OnePlus Nord Europe / Global
 
 **OnePlus Nord 2 (`denniz`):**
 
 `DN2101`: OnePlus Nord 2 India
 
-`DN2103`: OnePlus Nord 2 EU
+`DN2103`: OnePlus Nord 2 Europe
 
 **OnePlus Nord 2T (`karen`):**
 
@@ -311,11 +315,17 @@
 
 `CPH2401`: OnePlus Nord 2T India
 
+**OnePlus Nord 4 (`avalon`):**
+
+`CPH2661`: OnePlus Nord 4 India
+
+`CPH2663`: OnePlus Nord 4 Europe / Global
+
 **OnePlus Nord CE (`ebba`):**
 
 `EB2101`: OnePlus Nord CE India
 
-`EB2103`: OnePlus Nord CE EU / Global
+`EB2103`: OnePlus Nord CE Europe / Global
 
 **OnePlus Nord CE 2 (`ivan`):**
 
@@ -325,27 +335,31 @@
 
 `CPH2381`: OnePlus Nord CE 2 Lite India
 
-`CPH2409`: OnePlus Nord CE 2 Lite EU / Global
+`CPH2409`: OnePlus Nord CE 2 Lite Europe / Global
 
-**OnePlus Nord CE 3:**
+**OnePlus Nord CE 3 (`ziti`):**
 
 `CPH2569`: OnePlus Nord CE 3 India
 
-**OnePlus Nord CE 3 Lite:**
+**OnePlus Nord CE 3 Lite / OnePlus Nord N30 (`larry`):**
 
 `CPH2465`: OnePlus Nord CE 3 Lite Global
 
 `CPH2467`: OnePlus Nord CE 3 Lite India
 
-**OnePlus Nord CE4:**
+`CPH2513`: OnePlus Nord N30 North America
 
-`CPH2613`: OnePlus Nord CE4 India
+`CPH2515`: OnePlus Nord N30 T-Mobile
 
-**OnePlus Nord CE4 Lite:**
+**OnePlus Nord CE 4 (`benz`):**
 
-`CPH2619`: OnePlus Nord CE4 Lite India
+`CPH2613`: OnePlus Nord CE 4 India
 
-`CPH2621`: OnePlus Nord CE4 Lite EU / Global
+**OnePlus Nord CE 4 Lite (`camry`):**
+
+`CPH2619`: OnePlus Nord CE 4 Lite India
+
+`CPH2621`: OnePlus Nord CE 4 Lite Europe / Global
 
 **OnePlus Nord N10 (`billie8`):**
 
@@ -353,7 +367,7 @@
 
 `BE2026`: OnePlus Nord N10 North America
 
-`BE2029`: OnePlus Nord N10 EU / Global
+`BE2029`: OnePlus Nord N10 Europe / Global
 
 **OnePlus Nord N10 (`billie8t`):**
 
@@ -377,15 +391,9 @@
 
 `CPH2469`: OnePlus Nord 20 SE
 
-**OnePlus Nord N30:**
-
-`CPH2513`: OnePlus Nord N30 North America
-
-`CPH2515`: OnePlus Nord N30 T-Mobile
-
 **OnePlus Nord N30 SE (`fanli`):**
 
-`CPH2605`: OnePlus Nord N30 SE EU
+`CPH2605`: OnePlus Nord N30 SE Europe
 
 **OnePlus Nord N200 (`dre9`):**
 
@@ -401,7 +409,7 @@
 
 ## OnePlus Pads/Foldable Phones
 
-**OnePlus Open (`hedwig`):**
+**OnePlus Open (`hedwig`, `xueying`):**
 
 `CPH2551`: OnePlus Open
 
@@ -415,19 +423,21 @@
 
 `OPD2305`: OnePlus Pad Go Wi-Fi
 
-**OnePlus Pad Pro (`caihong`):**
+**OnePlus Pad 2 / OnePlus Pad Pro (`rainbow`, `caihong`):**
 
 `OPD2404`: OnePlus Pad Pro
 
+`OPD2403`: OnePlus Pad 2
+
 ## OnePlus Watches/Bands
 
-**OnePlus Band:**
+**OnePlus Band (`audio`):**
 
 `W101IN`: OnePlus Band India
 
-**OnePlus Nord Watch:**
+**OnePlus Nord Watch (`newton`):**
 
-`OPBBE221`: OnePlus Nord Watch Global
+`OPBBE221`: OnePlus Nord Watch
 
 **OnePlus Watch:**
 
@@ -437,10 +447,12 @@
 
 `W301GB`: OnePlus Watch Global / Cobalt Limited Edition (Global)
 
-**OnePlus Watch 2 China / OnePlus Watch 2R (`bagel`):**
+**OnePlus Watch 2R / OnePlus Watch 2 China (`bagel`):**
 
-`OPWW234`: OnePlus Watch 2 China
+`OPWW234`: OnePlus Watch 2 (CN)
+
+`OPWWE234`: OnePlus Watch 2R
 
 **OnePlus Watch 2 (`almond`):**
 
-`OPWWE231`: OnePlus Watch 2 Global
+`OPWWE231`: OnePlus Watch 2


### PR DESCRIPTION
OnePlus Open 和 OnePlus Pad 2 / OnePlus Pad Pro 官方代号是英文那个，但是代码里是拼音那个，方便参考还是都写上了

xigua 下面还有个 xiyou 的变体，本质还是同一款机器