### PR TITLE
update huawei_cn.md and huawei_global_en.md

### DIFF
--- a/brands/huawei_cn.md
+++ b/brands/huawei_cn.md
@@ -373,7 +373,7 @@
 
 **HUAWEI P40 Pro+ (`ElsaP`):**
 
-`ELS-AN10` `ELS-N39`: HUAWEI P40 Pro+ 5G 全网通版
+`ELS-AN10`: HUAWEI P40 Pro+ 5G 全网通版
 
 `ELS-TN10`: HUAWEI P40 Pro+ 5G 移动版
 

--- a/brands/huawei_cn.md
+++ b/brands/huawei_cn.md
@@ -373,7 +373,7 @@
 
 **HUAWEI P40 Pro+ (`ElsaP`):**
 
-`ELS-AN10`: HUAWEI P40 Pro+ 5G 全网通版
+`ELS-AN10` `ELS-N39`: HUAWEI P40 Pro+ 5G 全网通版
 
 `ELS-TN10`: HUAWEI P40 Pro+ 5G 移动版
 

--- a/brands/huawei_cn.md
+++ b/brands/huawei_cn.md
@@ -649,7 +649,7 @@
 
 **HUAWEI nova 12 活力版 (`Fiona`):**
 
-`FIN-AL60`: HUAWEI nova 12 活力版
+`FIN-AL60` `FIN-AL60a`: HUAWEI nova 12 活力版
 
 **HUAWEI nova 12 Pro (`Adela`):**
 

--- a/brands/huawei_global_en.md
+++ b/brands/huawei_global_en.md
@@ -241,6 +241,10 @@
 
 `ELS-NX9`: HUAWEI P40 Pro Dual SIM
 
+**HUAWEI P40 Pro (`ElsaP`):**
+
+`ELS-N39`: HUAWEI P40 Pro+
+
 **HUAWEI P40 lite (`Jenny`):**
 
 `JNY-LX1`: HUAWEI P40 lite Dual SIM


### PR DESCRIPTION
- 增加Huawei nova 12 活力版机型编号`FIN-AL60a`
- Huawei P40 Pro+海外型号`ELS-N39`具体可见[华为海外设备检索](https://consumer.huawei.com/kh/search/?keyword=ELS-N39&tag=support)