### PR TITLE
纠正联想和乐视机型开源情况

### DIFF
--- a/misc/bootloader-kernel-source.md
+++ b/misc/bootloader-kernel-source.md
@@ -76,7 +76,7 @@
 - **解锁后保修状态**: ⏹
 - **是否支持回锁**: ⏹
     - **是否支持自定义信任根**: ⏹
-- **Linux 内核开源**: ❌
+- **Linux 内核开源**: [⏹](https://support.lenovo.com/us/en/solutions/ht511330-lenovo-open-source-portal)
 - **备注**:
     - 申请解锁文件需登录联想账号
     - 部分设备无需申请解锁文件
@@ -90,7 +90,7 @@
 - **解锁等待时长**: 不详
 - **解锁后保修状态**: 不详
 - **是否支持回锁**: 不详
-- **Linux 内核开源**: ❌
+- **Linux 内核开源**: ⏹
 
 ## LG
 - **Bootloader 解锁**: [❌](https://developer.lge.com/resource/mobile/RetrieveBootloader.dev)


### PR DESCRIPTION
联想：部分机型开源在官方网站。
开源地址：https://support.lenovo.com/us/en/solutions/ht511330-lenovo-open-source-portal

乐视：初始开源地址不明，但在github中能找到乐视msm8996和msm8976和部分其他平台机型开源内核
例：
https://github.com/LineageOS/android_kernel_leeco_msm8996
https://github.com/LineageOS/android_kernel_leeco_msm8976