### PR TITLE
增加新的Mate 80 型号

### DIFF
--- a/brands/huawei_cn.md
+++ b/brands/huawei_cn.md
@@ -227,7 +227,7 @@
 
 **HUAWEI Mate 80 (`Voyager`):**
 
-`VYG-AL00`: HUAWEI Mate 80
+`VYG-AL00` `VYG-AL30`: HUAWEI Mate 80
 
 **HUAWEI Mate 80 Pro (`Sagittarius`):**
 


### PR DESCRIPTION
后续批次上市版本的Mate 80 型号为VYG-AL30